### PR TITLE
#7 GitHub ActionsでPHPUnitを並列で実行するように

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,92 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  push:
+
+# ワークフローレベルでパーミッションをすべて無効化
+permissions: { }
+
+# デフォルトシェルでパイプエラーを有効化
+defaults:
+  run:
+    shell: bash
+
+# ワークフローが複数起動したら古いワークフローは自動キャンセルする。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PHP-VERSION: 8.4.2
+  TZ: Asia/Tokyo
+  DB_HOST: 127.0.0.1
+  DB_DATABASE: testing
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        parallelism: [ 2 ]
+        id: [ 0, 1 ]
+
+    services:
+      postgres:
+        image: postgres:17.2-bullseye
+        env:
+          POSTGRES_USER: car_bike_auction
+          POSTGRES_DB: ${{ env.DB_DATABASE }}
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run actionlint
+        run: |
+          set -x
+          docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        with:
+          php-version: ${{ env.PHP-VERSION }}
+          ini-values: date.timezone=${{ env.TZ }}
+          extensions: bcmath zip intl pdo_pgsql
+
+      - name: Copy .env
+        run: cp .env.example .env
+
+      - name: Use Composer Cache
+        id: composer-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --quiet --no-interaction --no-ansi --no-scripts --no-progress --prefer-dist
+
+      - name: Generate key
+        run: php artisan key:generate
+
+      - name: Run migration
+        run: DB_DATABASE=${{ env.DB_DATABASE }} php artisan migrate --force
+
+      - name: Run Parallel Tests
+        env:
+          MATRIX_PARALLELISM: ${{ matrix.parallelism }}
+          MATRIX_ID: ${{ matrix.id }}
+        run: |
+          set -x
+          find tests -name '*Test.php' | sort | awk "NR % ${MATRIX_PARALLELISM} == ${MATRIX_ID}" | xargs php ./bin/generate_ci_phpunit_xml.php
+          ./vendor/bin/phpunit --order-by=random --configuration /tmp/ci_phpunit.xml

--- a/bin/generate_ci_phpunit_xml.php
+++ b/bin/generate_ci_phpunit_xml.php
@@ -1,0 +1,44 @@
+<?php
+
+$baseDir = realpath('./');
+$files = array_slice($argv, 1);
+$xmlFileStringData = [];
+foreach ($files as $file) {
+    $xmlFileStringData[] = "<file>{$baseDir}/{$file}</file>";
+}
+$testFileString = implode("\n", $xmlFileStringData);
+$template = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="{$baseDir}vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="{$baseDir}/vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Case">
+            {$testFileString}
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>"{$baseDir}/app"</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="DB_DATABASE" value="testing"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_STORE" value="array"/>
+        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
+        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="PULSE_ENABLED" value="false"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+    </php>
+</phpunit>
+XML;
+
+file_put_contents("/tmp/ci_phpunit.xml", $template);


### PR DESCRIPTION
## チケットへのリンク

Close #7 

## 関連するプルリクエスト

<!-- 過去のPRで関連するものがあればリンクを記載 -->



## やったこと
- PHPUnitをGitHub Actionsで並列実行するようにしました 
  - テストコードのロジックが実行順序に依存するのを防ぐため、ジョブ内でランダムで実行するようにしました

## やらないこと
- テストカバレッジ率の出力
- CircleCIにある`--split-by=timings`的な実行時間ベースでのテスト分割
  - もっとちゃんと最適化するならこれが理想だが現状そこまでやる必要もないので、とりあえず機械的にテスト分割するようにしてます。

## 特に注力してレビューしてほしいこと

<!-- 不安があってレビューしてほしい点などあれば記載 -->

## 動作確認

<!-- どのような動作確認を行ったのか　結果はどうか -->
- [x] CIがパスすること

## レビューに出す前の簡易チェックリスト
- https://github.com/Kiyo510/CarBikeAuction-backend/blob/084f0d29edf2ae70cb9c3be228ae0d74db557b03/.github/pr_review_check_list.md

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）-->